### PR TITLE
Add "type": "module" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,12 @@
     "version": "1.1.1",
     "description": "Handle clicks outside of your specified element.",
     "main": "index.js",
+    "type": "module",
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "author": "rster2002",
-    "license": "ISC",
+    "license": "MIT",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/rster2002/svelte-outside-click.git"


### PR DESCRIPTION
This PR adds
```json
"type": "module"
```
to the `package.json`. This indicates the package uses `export default` instead `module.exports`, and depending on your setup might be needed for the package to work properly. See [the documentation](https://nodejs.org/api/packages.html#type) for more information.

While I was there, I also changed the `package.json`'s indicated to `MIT` since the license in this repository is MIT & I thought it should be indicated correctly.